### PR TITLE
add formatting, git and nb-diff extensions

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -88,12 +88,20 @@ RUN conda install --quiet --yes \
     'bqplot' \
     'jupyter_bokeh' \
     'jupyter-server-proxy' \
+    'jupyterlab-git' \
+    'jupyterlab_code_formatter' \
+    'autopep8' \
+    'black' \
+    'isort' \
+    'yapf' \
     && jupyter labextension install jupyter-leaflet \
                                     @jupyter-widgets/jupyterlab-manager \
                                     bqplot \
                                     @jupyterlab/server-proxy \
                                     jupyterlab-topbar-extension \
                                     jupyterlab-system-monitor \
+                                    @jupyterlab/git \
+                                    nbdime-jupyterlab \
     && conda clean --all -f -y \
     && npm cache clean --force \
     && npm dedupe \


### PR DESCRIPTION
Hey,

I would like to propose some additional extension to the default juptyer lab installation on erda:)

- [git](https://github.com/jupyterlab/jupyterlab-git) (for easier handling of repositories)
- [nb-dime](https://nbdime.readthedocs.io/en/latest/extensions.html) (for diff views of notebooks)
- [code-formatter](https://jupyterlab-code-formatter.readthedocs.io/en/latest/index.html) (for automatic formatting of notebooks)

I build the resulting image locally and tested it briefly. I guess you normally add further tests?!

Best, 
Henry