### PR TITLE
Add IJulia Notebook

### DIFF
--- a/architecture.yml
+++ b/architecture.yml
@@ -278,3 +278,14 @@ architecture:
         image: python-notebook
         tag: latest
         pipeline_dependent: true
+  julia-notebook:
+    latest:
+      parent:
+        owner: ucphhpc
+        image: base-notebook
+        tag: latest
+        pipeline_dependent: true
+      parameters:
+        JULIA_MAJOR_VERSION: 1.9
+        JULIA_MINOR_VERSION: 4
+        JULIA_DOWNLOAD_MD5: 3503c6bc79c48b4e13178155ebe9cae5

--- a/architecture.yml
+++ b/architecture.yml
@@ -5,7 +5,7 @@ architecture:
       parent:
         owner: jupyter
         image: base-notebook
-        tag: lab-4.0.6
+        tag: lab-4.0.7
         pipeline_dependent: false
   python-notebook:
     latest:

--- a/julia-notebook/Dockerfile.j2
+++ b/julia-notebook/Dockerfile.j2
@@ -16,6 +16,7 @@ USER root
 RUN echo "[global]" > /etc/pip.conf \
     && echo "timeout=${PACKAGE_TIMEOUT}" >> /etc/pip.conf
 
+USER $NB_UID
 WORKDIR /tmp
 
 # Download and install Julia

--- a/julia-notebook/Dockerfile.j2
+++ b/julia-notebook/Dockerfile.j2
@@ -1,0 +1,41 @@
+FROM {{ parent }}
+LABEL MAINTAINER="Sebastian Larsen Prehn <slp@di.ku.dk>"
+
+ARG JULIA_MAJOR_VERSION={{ JULIA_MAJOR_VERSION }}
+ARG JULIA_MINOR_VERSION={{ JULIA_MINOR_VERSION }}
+ARG JULIA_VERSION={{ JULIA_MAJOR_VERSION }}.{{ JULIA_MINOR_VERSION }}
+ARG JULIA_DOWNLOAD_MD5={{ JULIA_DOWNLOAD_MD5 }}
+ARG JULIA_DOWNLOAD_URL="https://julialang-s3.julialang.org/bin/linux/x64/$JULIA_MAJOR_VERSION/julia-$JULIA_VERSION-linux-x86_64.tar.gz"
+ARG PACKAGE_TIMEOUT=60
+
+ENV JULIA_PATH=/opt/julia
+
+USER root
+
+# Setup default timeout of installing packages
+RUN echo "[global]" > /etc/pip.conf \
+    && echo "timeout=$PACKAGE_TIMEOUT" >> /etc/pip.conf
+
+WORKDIR /tmp
+
+# Download and install Julia
+RUN cd \
+    && wget -O julia.tar.gz "$JULIA_DOWNLOAD_URL" \
+    && echo "$JULIA_DOWNLOAD_MD5" julia.tar.gz |
+md5sum -c - \
+    && mkdir -p ${JULIA_PATH} \
+    && tar zxvf julia.tar.gz -C ${JULIA_PATH} --strip-component 1 \
+    && cd \
+    && rm -f julia.tar.gz
+
+# Add the julia environment to the jupyter kernel path
+RUN mamba run -n julia python3 /usr/local/bin/update_kernel_spec.py julia --env-kwargs PATH=$JULIA_PATH/bin/julia:$PATH
+
+# Install IJulia (https://julialang.github.io/IJulia.jl/stable/manual/installation/)
+RUN julia -e 'using Pkg; Pkg.add("IJulia")'
+
+
+WORKDIR "${HOME}"
+
+# Ensure that container Runs as
+USER $NB_UID

--- a/julia-notebook/Dockerfile.j2
+++ b/julia-notebook/Dockerfile.j2
@@ -5,7 +5,7 @@ ARG JULIA_MAJOR_VERSION={{ JULIA_MAJOR_VERSION }}
 ARG JULIA_MINOR_VERSION={{ JULIA_MINOR_VERSION }}
 ARG JULIA_VERSION={{ JULIA_MAJOR_VERSION }}.{{ JULIA_MINOR_VERSION }}
 ARG JULIA_DOWNLOAD_MD5={{ JULIA_DOWNLOAD_MD5 }}
-ARG JULIA_DOWNLOAD_URL="https://julialang-s3.julialang.org/bin/linux/x64/$JULIA_MAJOR_VERSION/julia-$JULIA_VERSION-linux-x86_64.tar.gz"
+ARG JULIA_DOWNLOAD_URL="https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_MAJOR_VERSION}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz"
 ARG PACKAGE_TIMEOUT=60
 
 ENV JULIA_PATH=/opt/julia
@@ -14,24 +14,22 @@ USER root
 
 # Setup default timeout of installing packages
 RUN echo "[global]" > /etc/pip.conf \
-    && echo "timeout=$PACKAGE_TIMEOUT" >> /etc/pip.conf
+    && echo "timeout=${PACKAGE_TIMEOUT}" >> /etc/pip.conf
 
 WORKDIR /tmp
 
 # Download and install Julia
-RUN cd \
-    && wget -O julia.tar.gz "$JULIA_DOWNLOAD_URL" \
-    && echo "$JULIA_DOWNLOAD_MD5" julia.tar.gz |
+RUN wget -O julia.tar.gz "${JULIA_DOWNLOAD_URL}" \
+    && echo "${JULIA_DOWNLOAD_MD5}" julia.tar.gz |
 md5sum -c - \
     && mkdir -p ${JULIA_PATH} \
     && tar zxvf julia.tar.gz -C ${JULIA_PATH} --strip-component 1 \
-    && cd \
     && rm -f julia.tar.gz
 
 # Add the julia environment to the jupyter kernel path
-RUN mamba run -n julia python3 /usr/local/bin/update_kernel_spec.py julia --env-kwargs PATH=$JULIA_PATH/bin/julia:$PATH
+RUN mamba run -n julia python3 /usr/local/bin/update_kernel_spec.py julia --env-kwargs PATH=${JULIA_PATH}/bin/julia:${PATH}
 
-# Install IJulia (https://julialang.github.io/IJulia.jl/stable/manual/installation/)
+# Install IJulia
 RUN julia -e 'using Pkg; Pkg.add("IJulia")'
 
 

--- a/julia-notebook/Dockerfile.j2
+++ b/julia-notebook/Dockerfile.j2
@@ -29,8 +29,12 @@ md5sum -c - \
 # Add the julia environment to the jupyter kernel path
 RUN mamba run -n julia python3 /usr/local/bin/update_kernel_spec.py julia --env-kwargs PATH=${JULIA_PATH}/bin/julia:${PATH}
 
-# Install IJulia
+# Install IJulia (installed separately)
 RUN julia -e 'using Pkg; Pkg.add("IJulia")'
+
+# A few core packages
+COPY packages.jl /tmp/
+RUN julia packages.jl
 
 
 WORKDIR "${HOME}"

--- a/julia-notebook/packages.jl
+++ b/julia-notebook/packages.jl
@@ -1,0 +1,8 @@
+using Pkg
+
+dependencies = [
+    "Oscar",
+    "HomotopyContinuation"
+]
+
+Pkg.add(dependencies)

--- a/julia-notebook/packages.jl
+++ b/julia-notebook/packages.jl
@@ -2,7 +2,8 @@ using Pkg
 
 dependencies = [
     "Oscar",
-    "HomotopyContinuation"
+    "HomotopyContinuation",
+    "DifferentialEquations"
 ]
 
 Pkg.add(dependencies)

--- a/julia-notebook/tests/notebooks/julia-path.ipynb
+++ b/julia-notebook/tests/notebooks/julia-path.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eca841cd-661f-4430-8a94-dedc27accf8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Test\n",
+    "\n",
+    "mycommand = `which julia`\n",
+    "\n",
+    "x = String(string(run(mycommand)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "783e74ea-2269-48dc-9261-da8adda0aabc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@test occursin(\"julia\", x)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/julia-notebook/tests/notebooks/julia.ipynb
+++ b/julia-notebook/tests/notebooks/julia.ipynb
@@ -94,14 +94,6 @@
    "source": [
     "@test π ≈ 3.14 atol=0.01"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6a6a01b1-a63d-4f4b-8044-74c010f7f8bd",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/julia-notebook/tests/notebooks/julia.ipynb
+++ b/julia-notebook/tests/notebooks/julia.ipynb
@@ -1,0 +1,122 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5c2fdf11-14f8-4c2d-84ff-7bfcc5574136",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "243af859-da14-491f-8c11-f2b696f9e7a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[32m\u001b[1mTest Passed\u001b[22m\u001b[39m"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@test 2 == 3 - 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "822a2ad9-0002-4f3c-9c3c-a05e8912f3fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[32m\u001b[1mTest Passed\u001b[22m\u001b[39m"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = pi * (12.34 / 2)^2\n",
+    "@test a == 119.59697657024448"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "d84ed396-f504-486a-974f-a68da183947b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[32m\u001b[1mTest Passed\u001b[22m\u001b[39m"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@test [1, 2] + [2, 1] == [3, 3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "0068040e-95fc-455d-bd36-3e24b88f7cf9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[32m\u001b[1mTest Passed\u001b[22m\u001b[39m"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@test π ≈ 3.14 atol=0.01"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a6a01b1-a63d-4f4b-8044-74c010f7f8bd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.9.4",
+   "language": "julia",
+   "name": "julia-1.9"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.9.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/julia-notebook/tests/notebooks/oscar.ipynb
+++ b/julia-notebook/tests/notebooks/oscar.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2d6b4885-df38-400e-a1fd-27ff2a75356a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Oscar\n",
+    "using Test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5f93d3e1-6885-4525-9967-1fdfec5a2feb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"abb\""
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "using Oscar.StraightLinePrograms; const SLP = Oscar.StraightLinePrograms;\n",
+    "\n",
+    "x, y, z = SLP.gens(SLProgram, 3);\n",
+    "\n",
+    "p = (x*y^2 + 1.3*z)^-1\n",
+    "\n",
+    "X, Y, Z = SLP.gens(Lazy, 3)\n",
+    "\n",
+    "test1 = SLP.evaluate(p, [2.0, 3.0, 5.0])\n",
+    "\n",
+    "test2 = SLP.evaluate(X*Y^2, ['a', 'b'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1b1b28b-1d1b-429a-a13a-e1efd12e589b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[32m\u001b[1mTest Passed\u001b[22m\u001b[39m"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@test test1 == 0.04081632653061224"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "93b9ded1-693b-4b01-bfee-930747df0ec0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[32m\u001b[1mTest Passed\u001b[22m\u001b[39m"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@test test2 == \"abb\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.9.4",
+   "language": "julia",
+   "name": "julia-1.9"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.9.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/julia-notebook/tests/requirements.txt
+++ b/julia-notebook/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest==7.1.2
+pytest-xdist==2.2.1
+nbformat==5.4.0

--- a/julia-notebook/tests/test.sh
+++ b/julia-notebook/tests/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pytest -n 4 --durations=0

--- a/julia-notebook/tests/test_notebook.py
+++ b/julia-notebook/tests/test_notebook.py
@@ -1,0 +1,51 @@
+import os
+import subprocess
+import tempfile
+import nbformat
+
+cur_path = os.path.abspath(".")
+notebooks_path = os.path.join(cur_path, "notebooks")
+kernels = ["julia-1.9"]
+
+
+def _notebook_run(path, kernel="julia-1.9", timeout=300):
+    """Execute a notebook via nbconvert and collect output.
+    :returns (parsed nb object, execution errors)
+    """
+    dirname, __ = os.path.split(path)
+    os.chdir(dirname)
+    with tempfile.NamedTemporaryFile(suffix=".ipynb") as fout:
+        args = [
+            "jupyter",
+            "nbconvert",
+            "--to",
+            "notebook",
+            "--execute",
+            "--ExecutePreprocessor.timeout={}".format(timeout),
+            "--ExecutePreprocessor.kernel_name={}".format(kernel),
+            "--output",
+            fout.name,
+            path,
+        ]
+        subprocess.check_call(args)
+
+        fout.seek(0)
+        nb = nbformat.read(fout, nbformat.current_nbformat)
+
+    errors = [
+        output
+        for cell in nb.cells
+        if "outputs" in cell
+        for output in cell["outputs"]
+        if output.output_type == "error"
+    ]
+    return nb, errors
+
+
+def test_notebooks():
+    for f_notebook in os.listdir(notebooks_path):
+        for kernel in kernels:
+            _, errors = _notebook_run(
+                os.path.join(notebooks_path, f_notebook), kernel=kernel
+            )
+            assert errors == []


### PR DESCRIPTION
Add Julia notebook support via [IJulia](https://github.com/JuliaLang/IJulia.jl) as requested in #48.

Creates a Notebook build which adds a Julia kernel, and enables Julia code to be executed in a Jupyter Notebook format.

# Testing

A basic test in Jupyter Notebook which tests importing standard libraries, some of the most basic mathematical operations, as well as a test to see whether it recognizes Julia's pi and approximation symbol.
```
using Test
```
```
@test 2 == 3 - 1
```
```
a = pi * (12.34 / 2)^2
@test a == 119.59697657024448
```
```
@test π ≈ 3.14 atol=0.01
```
The test environment should output "Test Passed" when run with Julia's kernel.