### PR TITLE
Fix LD library path RStudio

### DIFF
--- a/r-notebook/Dockerfile.j2
+++ b/r-notebook/Dockerfile.j2
@@ -134,6 +134,10 @@ RUN python3 /usr/local/bin/update_kernel_spec.py ir --env-kwargs PATH=$R_PATH/bi
 RUN chown -R $NB_USER:$NB_GID /var/lib/rstudio-server \
     && chown -R $NB_USER:$NB_GID /etc/rstudio
 
+# Fix LD library path for RStudio
+# https://github.com/rstudio/rstudio/issues/14060#issuecomment-1911329450
+RUN echo "rsession-ld-library-path=/opt/conda/lib" >> /etc/rstudio/rserver.conf
+
 # https://github.com/jupyterhub/jupyter-rsession-proxy
 # The rsession-proxy has to know whether version 1.4 is used
 ENV RSESSION_PROXY_RSTUDIO_1_4=True

--- a/r-notebook/Dockerfile.j2
+++ b/r-notebook/Dockerfile.j2
@@ -129,14 +129,14 @@ RUN echo "PATH=\"$R_PATH/bin:$PATH\"" >> /home/$NB_USER/.bashrc \
     && ln -s $R_PATH/bin/R /usr/local/bin/R
 RUN python3 /usr/local/bin/update_kernel_spec.py ir --env-kwargs PATH=$R_PATH/bin:$PATH
 
+# Fix LD library path for RStudio
+# https://github.com/rstudio/rstudio/issues/14060#issuecomment-1911329450
+RUN echo "rsession-ld-library-path=/opt/conda/lib" >> /etc/rstudio/rserver.conf
+
 # Rstudio version 1.4 has permissions problems as per.
 # https://community.rstudio.com/t/permissions-related-to-upgrade-to-rstudio-server-open-source-1-4/94256/3
 RUN chown -R $NB_USER:$NB_GID /var/lib/rstudio-server \
     && chown -R $NB_USER:$NB_GID /etc/rstudio
-
-# Fix LD library path for RStudio
-# https://github.com/rstudio/rstudio/issues/14060#issuecomment-1911329450
-RUN echo "rsession-ld-library-path=/opt/conda/lib" >> /etc/rstudio/rserver.conf
 
 # https://github.com/jupyterhub/jupyter-rsession-proxy
 # The rsession-proxy has to know whether version 1.4 is used


### PR DESCRIPTION
Moved fix up, and changed to dev branch.
Fix on LD library path to allow RStudio to install using curl / openssl.
Fix has been tested on local version of Big Data in Biotechnology Notebook.

Fix found here:
https://github.com/rstudio/rstudio/issues/14060#issuecomment-1911329450