### PR TITLE
Bump Julia notebook 1.10.10 -> 1.10.11

### DIFF
--- a/architecture.yml
+++ b/architecture.yml
@@ -492,8 +492,8 @@ architecture:
         pipeline_dependent: true
       parameters:
         JULIA_MAJOR_VERSION: "1.10"
-        JULIA_MINOR_VERSION: "10"
-        JULIA_DOWNLOAD_MD5: cdfcabb03bd8a09684b602aa25735371
+        JULIA_MINOR_VERSION: "11"
+        JULIA_DOWNLOAD_MD5: 1d807b525d37709894e7016301392d5d
         JULIA_CPU_TARGET: generic;icelake-server,clone_all;znver3,clone_all;znver2,clone_all;skylake-avx512,clone_all
     4.4.10:
       parent:
@@ -503,8 +503,8 @@ architecture:
         pipeline_dependent: true
       parameters:
         JULIA_MAJOR_VERSION: "1.10"
-        JULIA_MINOR_VERSION: "10"
-        JULIA_DOWNLOAD_MD5: cdfcabb03bd8a09684b602aa25735371
+        JULIA_MINOR_VERSION: "11"
+        JULIA_DOWNLOAD_MD5: 1d807b525d37709894e7016301392d5d
         JULIA_CPU_TARGET: generic;icelake-server,clone_all;znver3,clone_all;znver2,clone_all;skylake-avx512,clone_all
   cern-notebook:
     latest:


### PR DESCRIPTION
Julia 1.10 LTS received a minor update on May 10th, which mostly introduces some fixes and improvements. See changelog here: https://github.com/JuliaLang/julia/compare/v1.10.10...v1.10.11

test results:
```
docker run ucphhpc/julia-notebook:latest-test
============================= test session starts ==============================
platform linux -- Python 3.13.9, pytest-9.0.3, pluggy-1.6.0
rootdir: /app/tests
plugins: xdist-3.5.0, anyio-4.11.0
created: 4/4 workers
4 workers [1 item]

.                                                                        [100%]
============================== slowest durations ===============================
112.93s call     test_notebook.py::test_notebooks

(2 durations < 0.005s hidden.  Use -vv to show these durations.)
======================== 1 passed in 115.52s (0:01:55) =========================
```
Tested on Ubuntu 20.04.6 LTS:
```
NAME="Ubuntu"
VERSION="20.04.6 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.6 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```